### PR TITLE
GitHub Pages Guide: avoid "simply"

### DIFF
--- a/guides/github-pages-integration/README.md
+++ b/guides/github-pages-integration/README.md
@@ -4,7 +4,7 @@ This guide shows you how to use `utopia-project` with GitHub Pages.
 
 ## Static Site Generation
 
-Once you are happy with your project's documentation, simply generate a static site:
+Once you are happy with your project's documentation, use this command to generate a static site:
 
 ~~~ bash
 $ bake utopia:project:static


### PR DESCRIPTION
The former wording can needlessy trip someone up who doesn't feel like running that command is simple.

Searched for someone who wrote about this, and here's a tiny post about the subject: https://css-tricks.com/words-avoid-educational-writing/

I really like the guides!